### PR TITLE
RFC: Adapt Timer code to v0.4 changes (don't merge yet)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.3
-Compat 0.3.5
+Compat 0.4.6
 Images 0.4
 Color
 Tk

--- a/src/navigation.jl
+++ b/src/navigation.jl
@@ -20,12 +20,7 @@ end
 NavigationState(zmax::Integer, tmax::Integer, z::Integer, t::Integer) = NavigationState(@compat(Int(zmax)), @compat(Int(tmax)), @compat(Int(z)), @compat(Int(t)), nothing, 30.0)
 NavigationState(zmax::Integer, tmax::Integer) = NavigationState(zmax, tmax, 1, 1)
 
-function stop_playing!(state::NavigationState)
-    if !is(state.timer, nothing)
-        stop_timer(state.timer)
-        state.timer = nothing
-    end
-end
+stop_playing!(state::NavigationState) = close(state.timer)
 
 ## Type for holding "handles" to GUI controls
 type NavigationControls
@@ -235,8 +230,7 @@ function playz(inc, ctrls, state, showframe)
     end
     stop_playing!(state)
     dt = 1/state.fps
-    state.timer = VERSION >= v"0.3-" ? Timer(timer -> stepz(inc, ctrls, state, showframe)) : TimeoutAsyncWork((timer, status) -> stepz(inc, ctrls, state, showframe))
-    start_timer(state.timer, dt, dt)
+    state.timer = Timer(timer -> stepz(inc, ctrls, state, showframe), dt, dt)
 end
 
 function setz(ctrls,state, showframe)
@@ -277,8 +271,7 @@ function playt(inc, ctrls, state, showframe)
     end
     stop_playing!(state)
     dt = 1/state.fps
-    state.timer = VERSION >= v"0.3-" ? Timer(timer -> stept(inc, ctrls, state, showframe)) : TimeoutAsyncWork((timer, status) -> stept(inc, ctrls, state, showframe))
-    start_timer(state.timer, dt, dt)
+    state.timer = Timer(timer -> stept(inc, ctrls, state, showframe), dt, dt)
 end
 
 function sett(ctrls,state, showframe)


### PR DESCRIPTION
* depends on Compat for older Julia versions

This PR should only be merged after https://github.com/JuliaLang/Compat.jl/pull/103 is merged and a new Compat is tagged.

@timholy, these changes should be correct, but I don't have a good way to test them.