### PR TITLE
Provide scoping for Graphics.save

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+    - linux
+julia:
+    - 0.3
+    - release
 notifications:
   email: false
-env:
-  matrix: 
-    - JULIAVERSION="juliareleases" 
-    - JULIAVERSION="julianightlies" 
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install curl libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
-  - xvfb-run julia -e 'versioninfo(); Pkg.init(); Pkg.add("TestImages"); Pkg.clone(pwd()); Pkg.build("ImageView"); Pkg.test("ImageView")'
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'versioninfo(); Pkg.clone(pwd()); Pkg.build("ImageView")'
+  - xvfb-run julia -e 'Pkg.test("ImageView")'

--- a/src/annotations.jl
+++ b/src/annotations.jl
@@ -162,7 +162,7 @@ end
 function draw(c::Canvas, ann::AnchoredAnnotation)
     if ann.valid
         ctx = getgc(c)
-        save(ctx)
+        Graphics.save(ctx)
         data = ann.data
         set_coords(ctx, ann.devicebb(data), ann.userbb(data))
         scale_x = width(ann.userbb(data))/width(ann.devicebb(data))
@@ -174,7 +174,7 @@ end
 
 function draw{T}(c::Canvas, ann::FloatingAnnotation{AnnotationScalebarFixed{T}})
     ctx = getgc(c)
-    save(ctx)
+    Graphics.save(ctx)
     data = ann.data
     set_coords(ctx, ann.devicebb(data), BoundingBox(0,1,0,1))
     set_source(ctx, data.color)
@@ -238,7 +238,7 @@ function draw_pt(ctx::CairoContext, pt, sz_x, sz_y, shape::Char, color::Color, l
             circle(ctx, x, y, sz_x)
         else
             # draw an ellipse
-            save(ctx)
+            Graphics.save(ctx)
             translate(ctx, x, y)
             scale(ctx, sz_x, sz_y)
             new_sub_path(ctx)

--- a/src/display.jl
+++ b/src/display.jl
@@ -473,7 +473,7 @@ function redraw(imgc::ImageCanvas)
     # Define the path that encloses the image
     bb = imgc.canvasbb
     w, h = size(imgc.surface.data)  # the image width, height
-    save(r)
+    Graphics.save(r)
     reset_clip(r)
     reset_transform(r)
     wbb = width(bb)
@@ -694,7 +694,7 @@ end
 # Fill the entire canvas with a color
 function fill(r::GraphicsContext, col::Color)
     rgb = convert(RGB, col)
-    save(r)
+    Graphics.save(r)
     reset_clip(r)
     reset_transform(r)
     set_source_rgb(r, rgb.r, rgb.g, rgb.b)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 TestImages
+ImageMagick

--- a/test/tile.jl
+++ b/test/tile.jl
@@ -4,6 +4,6 @@ using TestImages
 
 c = ImageView.canvasgrid(2,2)
 ImageView.view(c[1,1], testimage("lighthouse"), pixelspacing=[1,1])
-ImageView.view(c[1,2], testimage("mountainstream", RGB), pixelspacing=[1,1])
+ImageView.view(c[1,2], testimage("mountainstream"), pixelspacing=[1,1])
 ImageView.view(c[2,1], testimage("moonsurface"), pixelspacing=[1,1])
 ImageView.view(c[2,2], testimage("mandrill"), pixelspacing=[1,1])


### PR DESCRIPTION
This is a minimal fix to get the tests working again. Pretty amazing, really, that this is all it took.

The deprecation warnings are outrageous, but that will be fixed eventually by the Gtk rewrite.
