### PR TITLE
add Cairo explicitly to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ Colors
 Tk
 Winston
 Graphics 0.1
+Cairo


### PR DESCRIPTION
instead of assuming it will be present from other dependencies


ImageView could also use a Travis badge in the readme.