### PR TITLE
Bump minimum julia to 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
     - linux
 julia:
-    - 0.3
     - 0.4
     - 0.5
     - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 Compat 0.7.20
 Images 0.4
 Colors


### PR DESCRIPTION
No new tags are accepted for julia 0.3, so let's make 0.4 the minimum version.