### PR TITLE
Add Reactive and ImageCore to test/REQUIRE

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -3,3 +3,5 @@ TestImages
 @windows ImageMagick
 @osx QuartzImageIO
 OffsetArrays
+ImageCore
+Reactive


### PR DESCRIPTION
since they're imported directly by the tests - they should
be present as transitive dependencies of GtkReactive and Images,
but hypothetically that might not always be the case